### PR TITLE
Prevent XSS

### DIFF
--- a/examples/index.php
+++ b/examples/index.php
@@ -5,7 +5,7 @@ $provider = require __DIR__ . '/provider.php';
 if (!empty($_GET['error'])) {
 
     // Got an error, probably user denied access
-    exit('Got error: ' . $_GET['error']);
+    exit('Got error: ' . htmlspecialchars($_GET['error'], ENT_QUOTES, 'UTF-8'));
 
 } elseif (empty($_GET['code'])) {
 


### PR DESCRIPTION
Showing the error from $_GET exposes the example to XSS attacks