### PR TITLE
Prevent XSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $provider = new League\OAuth2\Client\Provider\Google([
 if (!empty($_GET['error'])) {
 
     // Got an error, probably user denied access
-    exit('Got error: ' . $_GET['error']);
+    exit('Got error: ' . htmlspecialchars($_GET['error'], ENT_QUOTES, 'UTF-8'));
 
 } elseif (empty($_GET['code'])) {
 


### PR DESCRIPTION
Showing the error from $_GET exposes the example to XSS attacks (also on Readme example)