### PR TITLE
Move phony to be a dev-only dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,13 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
 
 matrix:
   include:
     - php: 5.6
       env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
+    - php: hhvm
+      dist: trusty
 
 before_script:
   - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
     ],
     "minimum-stability": "beta",
     "require": {
-        "league/oauth2-client": "^2.0",
-        "eloquent/phony": "^0.14.6"
+        "league/oauth2-client": "^2.0"
     },
     "require-dev": {
+        "eloquent/phony": "^0.14.6",
         "phpunit/phpunit": "^5.0",
         "satooshi/php-coveralls": "^1.0",
         "squizlabs/php_codesniffer": "^2.0"


### PR DESCRIPTION
I noticed an odd dependency when installing this package. I think the `eloquent/phony` should have been a dev requirement. But I think it's not really needed and can be solved with vanilla phpunit just as well.