### PR TITLE
Use correct token endpoint

### DIFF
--- a/src/Provider/Google.php
+++ b/src/Provider/Google.php
@@ -49,7 +49,7 @@ class Google extends AbstractProvider
 
     public function getBaseAccessTokenUrl(array $params)
     {
-        return 'https://accounts.google.com/o/oauth2/token';
+        return 'https://www.googleapis.com/oauth2/v4/token';
     }
 
     public function getResourceOwnerDetailsUrl(AccessToken $token)

--- a/test/src/Provider/GoogleTest.php
+++ b/test/src/Provider/GoogleTest.php
@@ -52,7 +52,7 @@ class GoogleTest extends \PHPUnit_Framework_TestCase
         $url = $this->provider->getBaseAccessTokenUrl([]);
         $uri = parse_url($url);
 
-        $this->assertEquals('/o/oauth2/token', $uri['path']);
+        $this->assertEquals('/oauth2/v4/token', $uri['path']);
     }
 
     public function testResourceOwnerDetailsUrl()


### PR DESCRIPTION
Endpoint is correct as per https://developers.google.com/identity/protocols/OAuth2WebServer#offline