### PR TITLE
Validate hosted domain of user

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $provider = new League\OAuth2\Client\Provider\Google([
     'clientId'     => '{google-app-id}',
     'clientSecret' => '{google-app-secret}',
     'redirectUri'  => 'https://example.com/callback-url',
-    'hostedDomain' => 'https://example.com',
+    'hostedDomain' => 'example.com',
 ]);
 
 if (!empty($_GET['error'])) {

--- a/src/Exception/HostedDomainException.php
+++ b/src/Exception/HostedDomainException.php
@@ -7,37 +7,9 @@ namespace League\OAuth2\Client\Exception;
  */
 class HostedDomainException extends \Exception
 {
-    private $hostedDomainConfigured;
 
-    private $hostedDomainOfUser;
-
-    /**
-     * HostedDomainException constructor.
-     * @param string $hostedDomainConfigured
-     * @param string|null $hostedDomainOfUser
-     */
-    public function __construct($hostedDomainConfigured, $hostedDomainOfUser)
+    public static function notMatchingDomain($configuredDomain)
     {
-        parent::__construct("Hosted domain mismatch '$hostedDomainOfUser' !== '$hostedDomainConfigured'");
-        $this->hostedDomainConfigured = $hostedDomainConfigured;
-        $this->hostedDomainOfUser = $hostedDomainOfUser;
-    }
-
-    /**
-     * The hosted domain configured for this provider.
-     * @return string
-     */
-    public function getHostedDomainConfigured()
-    {
-        return $this->hostedDomainConfigured;
-    }
-
-    /**
-     * The hosted domain of the user. Non G-Suite users do not have hosted domains
-     * @return string|null
-     */
-    public function getHostedDomainOfUser()
-    {
-        return $this->hostedDomainOfUser;
+        return new static("User is not part of domain '$configuredDomain''");
     }
 }

--- a/src/Exception/HostedDomainException.php
+++ b/src/Exception/HostedDomainException.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace League\OAuth2\Client\Exception;
+
+/**
+ * Exception thrown if the Google Provider is configured with a hosted domain that the user doesn't belong to
+ */
+class HostedDomainException extends \Exception
+{
+    private $hostedDomainConfigured;
+
+    private $hostedDomainOfUser;
+
+    /**
+     * HostedDomainException constructor.
+     * @param string $hostedDomainConfigured
+     * @param string|null $hostedDomainOfUser
+     */
+    public function __construct($hostedDomainConfigured, $hostedDomainOfUser)
+    {
+        parent::__construct("Hosted domain mismatch '$hostedDomainOfUser' !== '$hostedDomainConfigured'");
+        $this->hostedDomainConfigured = $hostedDomainConfigured;
+        $this->hostedDomainOfUser = $hostedDomainOfUser;
+    }
+
+    /**
+     * The hosted domain configured for this provider.
+     * @return string
+     */
+    public function getHostedDomainConfigured()
+    {
+        return $this->hostedDomainConfigured;
+    }
+
+    /**
+     * The hosted domain of the user. Non G-Suite users do not have hosted domains
+     * @return string|null
+     */
+    public function getHostedDomainOfUser()
+    {
+        return $this->hostedDomainOfUser;
+    }
+}

--- a/src/Provider/Google.php
+++ b/src/Provider/Google.php
@@ -127,10 +127,10 @@ class Google extends AbstractProvider
         // Validate hosted domain incase the user edited the initial authorization code grant request
         if ($this->hostedDomain === '*') {
             if (empty($user->getHostedDomain())) {
-                throw new HostedDomainException($this->hostedDomain, $user->getHostedDomain());
+                throw HostedDomainException::notMatchingDomain($this->hostedDomain);
             }
         } elseif (!empty($this->hostedDomain) && $this->hostedDomain !== $user->getHostedDomain()) {
-            throw new HostedDomainException($this->hostedDomain, $user->getHostedDomain());
+            throw HostedDomainException::notMatchingDomain($this->hostedDomain);
         }
 
         return $user;

--- a/src/Provider/Google.php
+++ b/src/Provider/Google.php
@@ -2,6 +2,7 @@
 
 namespace League\OAuth2\Client\Provider;
 
+use League\OAuth2\Client\Exception\HostedDomainException;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Token\AccessToken;
 use League\OAuth2\Client\Tool\BearerAuthorizationTrait;
@@ -64,7 +65,12 @@ class Google extends AbstractProvider
             // OIDC endpoints can be found https://accounts.google.com/.well-known/openid-configuration
             return 'https://www.googleapis.com/oauth2/v3/userinfo';
         }
-        $fields = array_merge($this->defaultUserFields, $this->userFields);
+        // fields that are required based on other configuration options
+        $configurationUserFields = [];
+        if (isset($this->hostedDomain)) {
+            $configurationUserFields[] = 'domain';
+        }
+        $fields = array_merge($this->defaultUserFields, $this->userFields, $configurationUserFields);
         return 'https://www.googleapis.com/plus/v1/people/me?' . http_build_query([
             'fields' => implode(',', $fields),
             'alt'    => 'json',
@@ -117,6 +123,16 @@ class Google extends AbstractProvider
 
     protected function createResourceOwner(array $response, AccessToken $token)
     {
-        return new GoogleUser($response);
+        $user = new GoogleUser($response);
+        // Validate hosted domain incase the user edited the initial authorization code grant request
+        if ($this->hostedDomain === '*') {
+            if (empty($user->getHostedDomain())) {
+                throw new HostedDomainException($this->hostedDomain, $user->getHostedDomain());
+            }
+        } elseif (!empty($this->hostedDomain) && $this->hostedDomain !== $user->getHostedDomain()) {
+            throw new HostedDomainException($this->hostedDomain, $user->getHostedDomain());
+        }
+
+        return $user;
     }
 }

--- a/src/Provider/GoogleUser.php
+++ b/src/Provider/GoogleUser.php
@@ -81,6 +81,23 @@ class GoogleUser implements ResourceOwnerInterface
     }
 
     /**
+     * Get hosted domain.
+     *
+     * @return string|null
+     */
+    public function getHostedDomain()
+    {
+        if (array_key_exists('hd', $this->response)) {
+            return $this->response['hd'];
+        }
+        if (array_key_exists('domain', $this->response)) {
+            return $this->response['domain'];
+        }
+
+        return null;
+    }
+
+    /**
      * Get avatar image URL.
      *
      * @return string|null

--- a/test/src/Provider/GoogleOIDCTest.php
+++ b/test/src/Provider/GoogleOIDCTest.php
@@ -5,6 +5,7 @@ namespace League\OAuth2\Client\Test\Provider;
 use Eloquent\Phony\Phpunit\Phony;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Provider\Google as GoogleProvider;
+use League\OAuth2\Client\Provider\GoogleUser;
 use League\OAuth2\Client\Token\AccessToken;
 
 class GoogleOIDCTest extends \PHPUnit_Framework_TestCase
@@ -74,7 +75,7 @@ class GoogleOIDCTest extends \PHPUnit_Framework_TestCase
     public function testUserData()
     {
         // Mock
-        $response = json_decode('{"email": "mock_email","sub": "12345","name": "mock_name", "family_name": "mock_last_name","given_name": "mock_first_name", "picture": "mock_image_url"}', true);
+        $response = json_decode('{"email": "mock_email","sub": "12345","name": "mock_name", "family_name": "mock_last_name","given_name": "mock_first_name", "picture": "mock_image_url", "hd": "example.com"}', true);
 
         $token = $this->mockAccessToken();
 
@@ -97,6 +98,7 @@ class GoogleOIDCTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('mock_first_name', $user->getFirstName());
         $this->assertEquals('mock_last_name', $user->getLastName());
         $this->assertEquals('mock_email', $user->getEmail());
+        $this->assertEquals('example.com', $user->getHostedDomain());
         $this->assertEquals('mock_image_url', $user->getAvatar());
 
         $user = $user->toArray();
@@ -104,6 +106,7 @@ class GoogleOIDCTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('sub', $user);
         $this->assertArrayHasKey('name', $user);
         $this->assertArrayHasKey('email', $user);
+        $this->assertArrayHasKey('hd', $user);
         $this->assertArrayHasKey('picture', $user);
         $this->assertArrayHasKey('family_name', $user);
     }

--- a/test/src/Provider/GoogleTest.php
+++ b/test/src/Provider/GoogleTest.php
@@ -64,6 +64,17 @@ class GoogleTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('/plus/v1/people/me', $uri['path']);
         $this->assertNotContains('mock_access_token', $url);
+
+        parse_str($uri['query'], $query);
+        $fields = explode(',', $query['fields']);
+        // Default values
+        $this->assertContains('displayName', $fields);
+        $this->assertContains('emails/value', $fields);
+        $this->assertContains('image/url', $fields);
+
+        // Domain is conditionally added if hostedDomain is set
+        $this->assertContains('domain', $fields);
+
     }
 
     public function testResourceOwnerDetailsUrlCustomFields()
@@ -107,7 +118,7 @@ class GoogleTest extends \PHPUnit_Framework_TestCase
     public function testUserData()
     {
         // Mock
-        $response = json_decode('{"emails": [{"value": "mock_email"}],"id": "12345","displayName": "mock_name","name": {"familyName": "mock_last_name","givenName": "mock_first_name"},"image": {"url": "mock_image_url"}}', true);
+        $response = json_decode('{"emails": [{"value": "mock_email"}],"id": "12345","displayName": "mock_name","name": {"familyName": "mock_last_name","givenName": "mock_first_name"},"image": {"url": "mock_image_url"}, "domain": "example.com"}', true);
 
         $token = $this->mockAccessToken();
 
@@ -130,6 +141,7 @@ class GoogleTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('mock_first_name', $user->getFirstName());
         $this->assertEquals('mock_last_name', $user->getLastName());
         $this->assertEquals('mock_email', $user->getEmail());
+        $this->assertEquals('example.com', $user->getHostedDomain());
         $this->assertEquals('mock_image_url', $user->getAvatar());
 
         $user = $user->toArray();
@@ -137,6 +149,7 @@ class GoogleTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('id', $user);
         $this->assertArrayHasKey('displayName', $user);
         $this->assertArrayHasKey('emails', $user);
+        $this->assertArrayHasKey('domain', $user);
         $this->assertArrayHasKey('image', $user);
         $this->assertArrayHasKey('name', $user);
     }

--- a/test/src/Provider/HostedDomainCheckTest.php
+++ b/test/src/Provider/HostedDomainCheckTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace League\OAuth2\Client\Test\Provider;
+
+use Eloquent\Phony\Phpunit\Phony;
+use League\OAuth2\Client\Exception\HostedDomainException;
+use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
+use League\OAuth2\Client\Provider\Google as GoogleProvider;
+use League\OAuth2\Client\Provider\GoogleUser;
+use League\OAuth2\Client\Token\AccessToken;
+
+class HostedDomainCheckTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * Test combinations of hosted domain and user data that are valid
+     *
+     * @dataProvider validHostedDomainProvider
+     * @param $providerConfig
+     * @param $json
+     * @param $expectedHostedDomain
+     */
+    public function testValidHostedDomains(array $providerConfig, $json, $expectedHostedDomain)
+    {
+        // Mock
+        $response = json_decode($json, true);
+
+        $token = $this->mockAccessToken();
+
+        $provider = Phony::partialMock(GoogleProvider::class, $providerConfig);
+        $provider->fetchResourceOwnerDetails->returns($response);
+        $google = $provider->get();
+
+        // Execute
+        /** @var GoogleUser $user */
+        $user = $google->getResourceOwner($token);
+
+        // Verify
+        Phony::inOrder(
+            $provider->fetchResourceOwnerDetails->called()
+        );
+
+        $this->assertInstanceOf('League\OAuth2\Client\Provider\ResourceOwnerInterface', $user);
+        $this->assertEquals($expectedHostedDomain, $user->getHostedDomain());
+
+    }
+
+    public function validHostedDomainProvider() {
+        // Any domain or no domain is allowed if not specified
+        $noHostedDomainConfig = [];
+        // Any domain is allowed if set to * (but it must be set.)
+        $wildCardHostedDomain = [['hostedDomain' => '*']];
+        // Matching domain is allowed
+        $hostedDomainConfig = [['hostedDomain' => 'example.com']];
+        return [
+            [ $noHostedDomainConfig, '{"email": "mock_email"}', null],
+            [ $noHostedDomainConfig, '{"email": "mock_email", "hd": "anything.example"}', "anything.example"],
+            [ $noHostedDomainConfig, '{"email": "mock_email", "domain": "anything.example"}', "anything.example"],
+            [ $wildCardHostedDomain, '{"email": "mock_email", "hd": "anything.example"}', "anything.example"],
+            [ $wildCardHostedDomain, '{"email": "mock_email", "domain": "anything.example"}', "anything.example"],
+            [ $hostedDomainConfig, '{"email": "mock_email", "hd": "example.com"}', "example.com"],
+            [ $hostedDomainConfig, '{"email": "mock_email", "domain": "example.com"}', "example.com"],
+
+        ];
+    }
+
+    /**
+     * Test combinations of hosted domain and user data that are invalid
+     *
+     * @dataProvider invalidHostedDomainProvider
+     * @param $json
+     */
+    public function testInvalidHostedDomains(array $providerConfig, $json)
+    {
+        $this->expectException(HostedDomainException::class);
+        // Mock
+        $response = json_decode($json, true);
+
+        $token = $this->mockAccessToken();
+
+        $provider = Phony::partialMock(GoogleProvider::class, $providerConfig);
+        $provider->fetchResourceOwnerDetails->returns($response);
+        $google = $provider->get();
+
+        // Execute
+        $google->getResourceOwner($token);
+    }
+
+    public function invalidHostedDomainProvider() {
+        // Wildcard requires a domain. No domain implies gmail
+        $wildCardHostedDomain = [['hostedDomain' => '*']];
+        // Matching domain is allowed
+        $hostedDomainConfig = [['hostedDomain' => 'example.com']];
+        return [
+            // A domain is required for wild cards
+            [ $wildCardHostedDomain, '{"email": "mock_email"}', null],
+            // A domain is required for specific domains
+            [ $hostedDomainConfig, '{"email": "mock_email"}', null],
+            [ $hostedDomainConfig, '{"email": "mock_email", "hd": "wrong.example.com"}'],
+            [ $hostedDomainConfig, '{"email": "mock_email", "domain": "example.co"}'],
+
+        ];
+    }
+
+    /**
+     * @return AccessToken
+     */
+    private function mockAccessToken()
+    {
+        return new AccessToken([
+            'access_token' => 'mock_access_token',
+        ]);
+    }
+}


### PR DESCRIPTION
If hostedDomain is configured then validate that user is from the hostedDomain.
Per https://developers.google.com/identity/protocols/OpenIDConnect#hd-param 'Be
sure to validate that the returned ID token has an hd claim value that matches
what you expect (e.g. mycolledge.edu). Unlike the request parameter, the ID
token claim is contained within a security token from Google, so the value can
be trusted.'