### PR TITLE
added clarification of what hostedDomain is for

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $provider = new League\OAuth2\Client\Provider\Google([
     'clientId'     => '{google-app-id}',
     'clientSecret' => '{google-app-secret}',
     'redirectUri'  => 'https://example.com/callback-url',
-    'hostedDomain' => 'example.com',
+    'hostedDomain' => 'example.com', // optional; used to restrict access to users on your G Suite/Google Apps for Business accounts
 ]);
 
 if (!empty($_GET['error'])) {


### PR DESCRIPTION
This helps clarify why the `hostedDomain` option is there. See https://github.com/thephpleague/oauth2-google/issues/55#issuecomment-375036973