### PR TITLE
Corrected getExpires() explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ if (!empty($_GET['error'])) {
     // Use this to get a new access token if the old one expires
     echo $token->getRefreshToken();
 
-    // Number of seconds until the access token will expire, and need refreshing
+    // Timestamp in seconds at which the access token expires, and needs refreshing
     echo $token->getExpires();
 }
 ```


### PR DESCRIPTION
AccessToken->getExpires() was wrongly documented as seconds until expiration and not as timestamp at which token expires.
https://github.com/thephpleague/oauth2-client/blob/3a0711216ff0659347ebffe82bd0ef726bb8d9b1/src/Token/AccessToken.php#L144