### PR TITLE
In README replace outdated 'approval_prompt' param with 'prompt'

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,10 +170,10 @@ $token = $provider->getAccessToken('authorization_code', [
 $refreshToken = $token->getRefreshToken();
 ```
 
-If you ever need to get a new refresh token you can request one by forcing the approval prompt:
+If you ever need to get a new refresh token you can request one by forcing the consent prompt:
 
 ```php
-$authUrl = $provider->getAuthorizationUrl(['approval_prompt' => 'force']);
+$authUrl = $provider->getAuthorizationUrl(['prompt' => 'consent']);
 ```
 
 Now you have everything you need to refresh an access token using a refresh token:


### PR DESCRIPTION
This pull request updates the README.

Param `approval_prompt` is no longer recognized by Google and does nothing. To make sure refresh token is present in the response, you need to set the `prompt` param to `consent`.