### PR TITLE
support multiple comma-separated patterns of hostedDomains

### DIFF
--- a/src/Provider/Google.php
+++ b/src/Provider/Google.php
@@ -54,7 +54,7 @@ class Google extends AbstractProvider
 
     protected function getAuthorizationParameters(array $options)
     {
-        if (empty($options['hd']) && $this->hostedDomain && !$this->multipleDomains()) {
+        if (empty($options['hd']) && $this->hostedDomain && !$this->isHostedDomainMultiple()) {
             $options['hd'] = $this->hostedDomain;
         }
 
@@ -127,12 +127,14 @@ class Google extends AbstractProvider
         return $user;
     }
 
-    protected static function isDomainExpression($str) {
+    protected function isDomainExpression($str)
+    {
         return preg_match('/[\(\|\*]/', $str) && !preg_match('!/!', $str);
     }
 
-    protected function multipleDomains() {
-        return strpos($this->hostedDomain, ',') !== FALSE || self::isDomainExpression($this->hostedDomain);
+    protected function isHostedDomainMultiple()
+    {
+        return strpos($this->hostedDomain, ',') !== FALSE || $this->isDomainExpression($this->hostedDomain);
     }
 
     /**
@@ -146,7 +148,7 @@ class Google extends AbstractProvider
         }
 
         $domains = array_filter(explode(',', $this->hostedDomain));
-        if (! $domains) {
+        if (empty($domains)) {
             // No hosted domains configured.
             return;
         }
@@ -175,7 +177,7 @@ class Google extends AbstractProvider
             return true;
         }
 
-        if (self::isDomainExpression($reference) && @preg_match('/' . $reference . '/', $hostedDomain)) {
+        if ($this->isDomainExpression($reference) && @preg_match('/' . $reference . '/', $hostedDomain)) {
             // Hosted domain is correct.
             return true;
         }

--- a/src/Provider/Google.php
+++ b/src/Provider/Google.php
@@ -19,8 +19,10 @@ class Google extends AbstractProvider
     protected $accessType;
 
     /**
-     * @var string Comma-separated list of domains or domain regular expressions.
-     *             If only one regular value is passed, it will be sent to google as the "hd" parameter.
+     * @var string If set, this will be sent to google as the "hd" parameter.
+     *             Extra-feature: Also accept a comma-separated list of domains or domain regular expressions.
+     *             In that case, Google connection screen is not bound to a specific hosted domain
+      *            because no "hd" parameter is sent to Google, but domain matching is still done by this library.
      * @link https://developers.google.com/identity/protocols/OpenIDConnect#authenticationuriparameters
      */
     protected $hostedDomain;

--- a/test/src/Provider/HostedDomainCheckTest.php
+++ b/test/src/Provider/HostedDomainCheckTest.php
@@ -53,11 +53,21 @@ class HostedDomainCheckTest extends TestCase
         $wildCardHostedDomain = [['hostedDomain' => '*']];
         // Matching domain is allowed
         $hostedDomainConfig = [['hostedDomain' => 'example.com']];
+        // Multiple domains is allowed
+        $multipleDomainsConfig = [['hostedDomain' => 'example.com,example.bar']];
+        // Multiple empty domains are like allowing any domain
+        $multipleEmptyDomainsConfig = [['hostedDomain' => ',']];
+        // One domain contains a regexp
+        $regexpDomainsConfig = [['hostedDomain' => 'example.(org|com)']];
+
         return [
             [ $noHostedDomainConfig, '{"email": "mock_email"}', null],
             [ $noHostedDomainConfig, '{"email": "mock_email", "hd": "anything.example"}', "anything.example"],
             [ $wildCardHostedDomain, '{"email": "mock_email", "hd": "anything.example"}', "anything.example"],
             [ $hostedDomainConfig, '{"email": "mock_email", "hd": "example.com"}', "example.com"],
+            [ $multipleDomainsConfig, '{"email": "mock_email", "hd": "example.com"}', "example.com"],
+            [ $multipleEmptyDomainsConfig, '{"email": "mock_email", "hd": "example.com"}', "example.com"],
+            [ $regexpDomainsConfig, '{"email": "mock_email", "hd": "example.com"}', "example.com"],
         ];
     }
 
@@ -89,12 +99,19 @@ class HostedDomainCheckTest extends TestCase
         $wildCardHostedDomain = [['hostedDomain' => '*']];
         // Matching domain is allowed
         $hostedDomainConfig = [['hostedDomain' => 'example.com']];
+        // No matching domains using regexp
+        $multipleDomainsConfig = [['hostedDomain' => 'example.(bar|baz),example.(foo),example.co']];
+        // Error regexp
+        $errorRegexp = [['hostedDomain' => 'example.com(']];
+
         return [
             // A domain is required for wild cards
             [ $wildCardHostedDomain, '{"email": "mock_email"}', null],
             // A domain is required for specific domains
             [ $hostedDomainConfig, '{"email": "mock_email"}', null],
             [ $hostedDomainConfig, '{"email": "mock_email", "hd": "wrong.example.com"}'],
+            [ $multipleDomainsConfig, '{"email": "mock_email", "hd": "example.com"}', null],
+            [ $errorRegexp, '{"email": "mock_email", "hd": "example.com"}', null],
         ];
     }
 


### PR DESCRIPTION
This provides support for extended domain restriction, eg:
`hd: mycompany.(org|com),mysubsidiary.tel`.

- Backward-compatible enhancement. Heuristic is preserved: `User-provided domain is tested (unanchored) again each of the domain's (string or patterns) and must match at least one in order to be allowed.`
- This is possible because none of the following 5 characters are part of a valid domain name: `, | ( ) *`
- Google connection prompt restriction is still active (passing `?hd=`), but only if the value of the `hostedDomain` represents one regular (non-pattern) domain.