### PR TITLE
FIX: doc for force refresh token

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ $refreshToken = $token->getRefreshToken();
 If you ever need to get a new refresh token you can request one by forcing the consent prompt:
 
 ```php
-$authUrl = $provider->getAuthorizationUrl(['prompt' => 'consent']);
+$authUrl = $provider->getAuthorizationUrl(['prompt' => 'consent','access_type'=>'offline']);
 ```
 
 Now you have everything you need to refresh an access token using a refresh token:


### PR DESCRIPTION
Forcing to generate refresh token requires the parameter `'access_type'=>'offline'`