### PR TITLE
Added some spaces in readme code example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ $refreshToken = $token->getRefreshToken();
 If you ever need to get a new refresh token you can request one by forcing the consent prompt:
 
 ```php
-$authUrl = $provider->getAuthorizationUrl(['prompt' => 'consent','access_type'=>'offline']);
+$authUrl = $provider->getAuthorizationUrl(['prompt' => 'consent', 'access_type'=>'offline']);
 ```
 
 Now you have everything you need to refresh an access token using a refresh token:

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ $refreshToken = $token->getRefreshToken();
 If you ever need to get a new refresh token you can request one by forcing the consent prompt:
 
 ```php
-$authUrl = $provider->getAuthorizationUrl(['prompt' => 'consent', 'access_type'=>'offline']);
+$authUrl = $provider->getAuthorizationUrl(['prompt' => 'consent', 'access_type' => 'offline']);
 ```
 
 Now you have everything you need to refresh an access token using a refresh token:


### PR DESCRIPTION
The code example on how to request a refresh token missed some spaces.
This made the example code a bit harder to read in a natural way.