### PR TITLE
Support for ID token verification

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,5 +39,8 @@
     },
     "scripts": {
         "check": "phpcs src test --standard=PSR12 -sp"
+    },
+    "suggest": {
+        "google/apiclient": "Enables validating ID tokens."
     }
 }

--- a/src/Provider/Google.php
+++ b/src/Provider/Google.php
@@ -2,6 +2,8 @@
 
 namespace League\OAuth2\Client\Provider;
 
+use Firebase\JWT\JWK;
+use Google\Client;
 use League\OAuth2\Client\Exception\HostedDomainException;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Token\AccessToken;
@@ -124,6 +126,16 @@ class Google extends AbstractProvider
 
         $this->assertMatchingDomain($user->getHostedDomain());
 
+        return $user;
+    }
+
+    public function createResourceOwnerFromIdToken(string $idToken): GoogleUser {
+        if (!class_exists(Client::class)) {
+            throw new \RuntimeException('google/apiclient library required for ID token verification.');
+        }
+        $client = new Client(['client_id' => $this->clientId]);
+        $user = new GoogleUser($client->verifyIdToken($idToken));
+        $this->assertMatchingDomain($user->getHostedDomain());
         return $user;
     }
 

--- a/src/Provider/GoogleUser.php
+++ b/src/Provider/GoogleUser.php
@@ -2,6 +2,8 @@
 
 namespace League\OAuth2\Client\Provider;
 
+use Google\Client;
+
 class GoogleUser implements ResourceOwnerInterface
 {
     /**


### PR DESCRIPTION
Native apps can receive ID tokens directly from Google in that auth flow; this provides some basic support with an eye toward more OIDC integration in this library.