### PR TITLE
Fixes Content-Type header syntax in provider.php for the example code

### DIFF
--- a/examples/provider.php
+++ b/examples/provider.php
@@ -19,6 +19,6 @@ session_start();
 $provider = new Google(compact('clientId', 'clientSecret', 'redirectUri'));
 
 // No HTML for demo, prevents any attempt at XSS
-header('Content-Type', 'text/plain');
+header('Content-Type: text/plain');
 
 return $provider;


### PR DESCRIPTION
The parameters to the `header()` function in `provider.php` in the example code are incorrect. The header should be in the first parameter of the function. It was causing issues when tested behind a reverse proxy, but seemed to work fine when only using the Development server.

Might save people some headaches in the future.