### PR TITLE
force_ip_resolve to ip4 for requests to Google APIs

### DIFF
--- a/src/Provider/Google.php
+++ b/src/Provider/Google.php
@@ -36,6 +36,12 @@ class Google extends AbstractProvider
      */
     protected $scopes = [];
 
+    public function getResponse(RequestInterface $request)
+    {
+        // Google is super slow without this
+        return $this->getHttpClient()->send($request, ['force_ip_resolve' => 'v4']);
+    }
+
     public function getBaseAuthorizationUrl(): string
     {
         return 'https://accounts.google.com/o/oauth2/v2/auth';


### PR DESCRIPTION
Seeing the API requests be super slow... seems to be a general issue.

See:
- https://stackoverflow.com/a/37442588/11394377
- https://github.com/googleapis/google-api-python-client/issues/2216
- https://stackoverflow.com/a/44862717/11394377