### PR TITLE
feat: added getEmailVerified() and isEmailTrustworthy()

### DIFF
--- a/src/Provider/GoogleUser.php
+++ b/src/Provider/GoogleUser.php
@@ -73,6 +73,36 @@ class GoogleUser implements ResourceOwnerInterface
     }
 
     /**
+     * Get email_verified attribute.
+     *
+     * @return bool|null
+     */
+    public function getEmailVerified(): ?bool
+    {
+        return $this->getResponseValue('email_verified');
+    }
+
+    /**
+     * Returns whether the email is trustable enough to be used for authentication purpose.
+     *
+     * @see https://developers.google.com/identity/gsi/web/guides/verify-google-id-token
+     */
+    public function isEmailTrustworthy(): bool
+    {
+        $email = $this->getEmail();
+        if (! $email) {
+            return false;
+        }
+        if ('@gmail.com' === substr($email, -10)) {
+            return true;
+        }
+        if ($this->getHostedDomain() && $this->getEmailVerified()) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * Get hosted domain.
      *
      * @return string|null


### PR DESCRIPTION
Based on Google documentation, we can expose if the email was verified, but also some logic to know if the email can be used for authentication purposes, or not.

See relevant documentation https://developers.google.com/identity/gsi/web/guides/verify-google-id-token