### PR TITLE
Add defaultScopes property to Google provider

### DIFF
--- a/src/Provider/Google.php
+++ b/src/Provider/Google.php
@@ -36,6 +36,8 @@ class Google extends AbstractProvider
      */
     protected $scopes = [];
 
+    public array $defaultScopes = [];
+
     public function getBaseAuthorizationUrl(): string
     {
         return 'https://accounts.google.com/o/oauth2/v2/auth';


### PR DESCRIPTION
We need to add the property $defaultScopes to fixes Class League\OAuth2\Client\Provider\Google contains 1 abstract method and must therefore be declared abstract or implement the remaining method (League\OAuth2\Client\Provider\AbstractProvider::$defaultScopes::get) in PHP 8.5+